### PR TITLE
Add instruction to install gemnasium/migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
+[![Build Status](https://travis-ci.com/thakkarparth007/dalal-street-server.svg?token=8v3CJzGiBxKjxGqb6pbU&branch=master)](https://travis-ci.com/thakkarparth007/dalal-street-server)
+
 # Server for Dalal Street
 
 ## Setup instructions
 
 - You must have Go 1.7+ [installed](https://golang.org/doc/install) and [configured](https://golang.org/doc/install#testing).
 - Set your `$GOPATH` in your `.bashrc`. (Just a place where you want to keep all your Go code)
-- Append `$GOPATH/bin` to your `$PATH`.
+- Append `$GOPATH/bin` to your `$PATH`. Add the line `PATH=$PATH:$GOPATH/bin` to your `.bashrc`.
 - Clone this repository.
     - `go get github.com/thakkarparth007/dalal-street-server` (**recommended**)
     - `git clone git@github.com:thakkarparth007/dalal-street-server.git` (In this case, make sure you clone the repository in `$GOPATH/src/github.com/thakkarparth007`)
@@ -13,9 +15,11 @@
 ```
 cd dalal-street-server
 go get -v ./...
-migrate -url "mysql://root:YOUR_MYSQL_ROOT_PASSWORD@/YOUR_DATABASE_NAME" -path ./migrations up
-git submodule init
-git submodule update
+go get -v github.com/gemnasium/migrate
+mysql -u root -p -e "CREATE DATABASE dalalstreet_dev"
+migrate -url "mysql://root:YOUR_MYSQL_ROOT_PASSWORD@/dalalstreet_dev" -path ./migrations up
+git config --local status.submoduleSummary true
+git submodule update --init --recursive
 cd socketapi
 ./build_proto.sh
 
@@ -24,7 +28,7 @@ cd socketapi
 - Run `go run main.go`
 
 ## Docker usage instructions
-- Install `docker` and `docker-compose`.
+- Install [docker](https://docs.docker.com/engine/installation) and [docker-compose](https://docs.docker.com/compose/install).
 - Run `cp .env.example .env`. Fill in the *DB_NAME* and *DB_PASS* in *.env*. These are the credentials for the database container.
 - Use the same credentials in `Docker` section *config.json* (*DbName* and *DbPassword*) and *docker-entry.sh* (in the `migrate` command).
 - Run `docker-compose up`.


### PR DESCRIPTION
- Install `gemnasium/migrate` explicitly.
- Add links to install *docker* and *docker-compose*
- Add mysql command to create the development database.
- Add Travis build status badge.
- Add submodule summary to `git status`.