### PR TITLE
Fix minor error in Login test. Read test pwd from config

### DIFF
--- a/models/User_test.go
+++ b/models/User_test.go
@@ -14,7 +14,7 @@ func Test_Login(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder("POST", "https://api.pragyan.org/event/login", httpmock.NewStringResponder(200, `{"status_code":200,"message": { "user_id": "2", "user_fullname": "TestName" }}`))
+	httpmock.RegisterResponder("POST", "https://api.pragyan.org/event/login", httpmock.NewStringResponder(200, `{"status_code":200,"message": { "user_id": 2, "user_fullname": "TestName" }}`))
 
 	u, err := Login("test@testmail.com", "password")
 	if err != nil {

--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,12 @@ export DALAL_ENV=Test
 go test -v -run="^(Test|Benchmark)[^_](.*)" ./... -args -config="$(pwd)/config.json"
 
 # Integration tests
-migrate -url mysql://root:@/dalalstreet_test -path ./migrations up 
+
+# Get db password from "Test" section of config.json
+dbPass=$(egrep "Test|DbPassword" config.json \
+	| grep -C1 "Test" | tail -n1 \
+	| awk '{print substr($2,2,length($2)-3)}')
+
+migrate -url mysql://root:$dbPass@/dalalstreet_test -path ./migrations up 
 go test -race -v -p=1 -run="^(Test|Benchmark)_(.*)" ./... -args -config="$(pwd)/config.json"
-migrate -url mysql://root:@/dalalstreet_test -path ./migrations down 
+migrate -url mysql://root:$dbPass@/dalalstreet_test -path ./migrations down 


### PR DESCRIPTION
A previous commit synced login with Pragyan API login response
format. This one fixes the login test that used older format
and failed as a result.

Secondly, this commit makes test.sh read the database password
from the Test section of config.json. This troubled Gautham
as he had set password for his local MySQL installation instead
of default empty password.