### PR TITLE
Pragyan API responds with 400 for not-registerd as well :(

### DIFF
--- a/grpcapi/actionservice/DalalActionService.go
+++ b/grpcapi/actionservice/DalalActionService.go
@@ -229,7 +229,7 @@ func (d *dalalActionService) Login(ctx context.Context, req *actions_pb.LoginReq
 
 	switch {
 	case err == models.UnauthorizedError:
-		return makeError(actions_pb.LoginResponse_InternalServerError, "Incorrect username/password combination. Please use your Pragyan credentials.")
+		return makeError(actions_pb.LoginResponse_InvalidCredentialsError, "Incorrect username/password combination. Please use your Pragyan credentials.")
 	case err == models.NotRegisteredError:
 		return makeError(actions_pb.LoginResponse_InvalidCredentialsError, "You have not registered for Dalal Street on the Pragyan website")
 	case err != nil:


### PR DESCRIPTION
This causes the tests to fail. Which is not good.
This code is brittle. We have no way to know if the
code written by us is wrong or the credentials are wrong.
This change assumes our code won't be wrong most of the times.