### PR TITLE
Increase datastream update frequency. Experimental.

### DIFF
--- a/datastreams/MarketDepth.go
+++ b/datastreams/MarketDepth.go
@@ -94,7 +94,7 @@ func (mds *marketDepthStream) run() {
 	for {
 		if mds.broadcastStream.GetListenersCount() == 0 {
 			l.Debugf("No listeners. Sleeping for 15 seconds")
-			time.Sleep(time.Minute / 4)
+			time.Sleep(time.Second * 2)
 			continue
 		}
 
@@ -131,13 +131,13 @@ func (mds *marketDepthStream) run() {
 
 		if !shouldSend {
 			l.Debugf("No update to send. Sleeping for 15 seconds")
-			time.Sleep(time.Minute / 4)
+			time.Sleep(time.Second * 2)
 			continue
 		}
 
 		mds.broadcastStream.BroadcastUpdate(mdUpdate)
 		l.Debugf("Sent %+v to %d listeners! Sleeping for 15 seconds", mdUpdate, mds.broadcastStream.GetListenersCount())
-		time.Sleep(time.Minute / 4)
+		time.Sleep(time.Second * 2)
 	}
 }
 

--- a/datastreams/StockExchange.go
+++ b/datastreams/StockExchange.go
@@ -58,7 +58,7 @@ func (ses *stockExchangeStream) Run() {
 		if len(ses.dirtyStocksInExchange) == 0 {
 			ses.stockExchangeMutex.Unlock()
 			l.Debugf("Nothing dirty yet. Sleeping for 15 seconds")
-			time.Sleep(time.Minute / 4)
+			time.Sleep(time.Second * 5)
 			continue
 		}
 
@@ -72,7 +72,7 @@ func (ses *stockExchangeStream) Run() {
 		ses.broadcastStream.BroadcastUpdate(updateProto)
 		l.Debugf("Sent to %d listeners!. Sleeping for 15 seconds", ses.broadcastStream.GetListenersCount())
 
-		time.Sleep(time.Minute / 4)
+		time.Sleep(time.Second * 5)
 	}
 }
 

--- a/datastreams/StockPrices.go
+++ b/datastreams/StockPrices.go
@@ -57,7 +57,7 @@ func (sps *stockPricesStream) Run() {
 		if len(sps.dirtyStocks) == 0 {
 			sps.stockPricesMutex.Unlock()
 			l.Debugf("Nothing dirty yet. Sleeping for 15 seconds")
-			time.Sleep(time.Minute / 4)
+			time.Sleep(time.Second * 5)
 			continue
 		}
 
@@ -72,7 +72,7 @@ func (sps *stockPricesStream) Run() {
 
 		l.Debugf("Sent to %d listeners! Sleeping for 15 seconds", sps.broadcastStream.GetListenersCount())
 
-		time.Sleep(time.Minute / 4)
+		time.Sleep(time.Second * 5)
 	}
 }
 


### PR DESCRIPTION
Reduced market depth updates interval to 1s, and stockprices, and stockexchange to 5s.
Just playing around, might need to increase the interval - depending upon the load.