### PR TITLE
[test]: Fix Mortgage transaction tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
     working_directory: /go/src/github.com/delta/dalal-street-server
     docker:
       - image: circleci/golang:1.10
-        environment:
-          MYSQL_HOST: 127.0.0.1:3306
       - image: circleci/mysql:5.7
 
     steps:

--- a/models/User.go
+++ b/models/User.go
@@ -1445,7 +1445,7 @@ func PerformMortgageTransaction(userId, stockId uint32, stockQuantity int32) (*T
 		MortgagePutLimitRWMutex.RLock()
 		lim := MortgagePutLimit
 		MortgagePutLimitRWMutex.RUnlock()
-		if user.Total < lim {
+		if user.Total > lim {
 			return nil, WayTooMuchCashError{}
 		}
 

--- a/models/User_test.go
+++ b/models/User_test.go
@@ -778,9 +778,9 @@ func Test_PerformMortgageRetrieveTransaction(t *testing.T) {
 	}
 
 	stocks := []*Stock{
-		{Id: 1, CurrentPrice: 100},
-		{Id: 2, CurrentPrice: 500},
-		{Id: 3, CurrentPrice: 200},
+		{Id: 1, CurrentPrice: 100, AvgLastPrice: 100},
+		{Id: 2, CurrentPrice: 500, AvgLastPrice: 500},
+		{Id: 3, CurrentPrice: 200, AvgLastPrice: 200},
 	}
 
 	transactions := []*Transaction{
@@ -912,9 +912,9 @@ func Test_PerformMortgageDepositTransaction(t *testing.T) {
 	}
 
 	stocks := []*Stock{
-		{Id: 1, CurrentPrice: 100},
-		{Id: 2, CurrentPrice: 500},
-		{Id: 3, CurrentPrice: 200},
+		{Id: 1, CurrentPrice: 100, AvgLastPrice: 100},
+		{Id: 2, CurrentPrice: 500, AvgLastPrice: 500},
+		{Id: 3, CurrentPrice: 200, AvgLastPrice: 200},
 	}
 
 	transactions := []*Transaction{

--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,7 @@ dbPass=$(egrep "Test|DbPassword" config.json \
 	| grep -C1 "Test" | tail -n1 \
 	| awk '{print substr($2,2,length($2)-3)}')
 
-migrate -url mysql://root:$dbPass@$MYSQL_HOST/dalalstreet_test -path ./migrations up
+migrate -url mysql://root:$dbPass@/dalalstreet_test -path ./migrations up
 go test -race -v -p=1 -run="^(Test|Benchmark)_(.*)" ./... -args -config="$(pwd)/config.json"
 code=$?
 migrate -url mysql://root:$dbPass@/dalalstreet_test -path ./migrations down 


### PR DESCRIPTION
We switched to `AvgLastPrice` instead of `CurrentPrice` for mortgage transactions last year, during the event. But the tests were still using `CurrentPrice`.

Moreover, there was probably a logical bug for determining `WayTooMuchCashError` in `PerformMortgageTransaction`.