### PR TITLE
[tax]: Fixes deadlock issue when writing to TransactionSummary table

### DIFF
--- a/migrations/20190128142845_add_autoincrement_column_to_transaction_summary.down.sql
+++ b/migrations/20190128142845_add_autoincrement_column_to_transaction_summary.down.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS TransactionSummary;
+
+CREATE TABLE IF NOT EXISTS TransactionSummary(
+	userId int(11) UNSIGNED NOT NULL,
+    stockId int(11) UNSIGNED NOT NULL,
+    stockQuantity bigint(11) SIGNED NOT NULL,
+    price float(11,2) UNSIGNED NOT NULL,
+	FOREIGN KEY (userId) REFERENCES Users(id),
+    FOREIGN KEY (stockId) REFERENCES Stocks(id),
+	PRIMARY KEY (userId, stockId)
+	) AUTO_INCREMENT = 1;

--- a/migrations/20190128142845_add_autoincrement_column_to_transaction_summary.up.sql
+++ b/migrations/20190128142845_add_autoincrement_column_to_transaction_summary.up.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS TransactionSummary;
+
+CREATE TABLE IF NOT EXISTS TransactionSummary(
+    id int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+	userId int(11) UNSIGNED NOT NULL,
+    stockId int(11) UNSIGNED NOT NULL,
+    stockQuantity bigint(11) SIGNED NOT NULL,
+    price float(11,2) UNSIGNED NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY NONCLUSTERED (userId, stockId),
+	FOREIGN KEY (userId) REFERENCES Users(id),
+    FOREIGN KEY (stockId) REFERENCES Stocks(id)
+) AUTO_INCREMENT=1;

--- a/models/TransactionSummary.go
+++ b/models/TransactionSummary.go
@@ -4,8 +4,9 @@ package models
 TransactionSummary models entries to the TransactionSummary table
 */
 type TransactionSummary struct {
-	UserId        uint32  `gorm:"primary_key;column:userId;not null"`
-	StockId       uint32  `gorm:"primary_key;column:stockId;not null"`
+	Id            uint32  `gorm:"primary_key;AUTO_INCREMENT" json:"id"`
+	UserId        uint32  `gorm:"column:userId;not null"`
+	StockId       uint32  `gorm:"column:stockId;not null"`
 	StockQuantity int64   `gorm:"column:stockQuantity;not null"`
 	Price         float64 `gorm:"column:price;not null"`
 }

--- a/models/User.go
+++ b/models/User.go
@@ -1143,11 +1143,11 @@ func getTaxForBiddingUser(tx *gorm.DB, stockId uint32, stockQuantity uint64, sto
 	var tax uint64
 
 	transactionSummary := &TransactionSummary{UserId: userId, StockId: stockId}
-	tx.First(&transactionSummary)
+	tx.Where("userId = ? AND stockId = ?", userId, stockId).First(&transactionSummary)
 
 	l.Debugf("TransactionSummary object retrieved : %+v", transactionSummary)
 
-	if transactionSummary.StockQuantity != 0 {
+	if transactionSummary.Id != 0 {
 		// This user has already placed orders for this stock before
 		currentStocksHeld := float64(transactionSummary.StockQuantity)
 		if currentStocksHeld < 0 {
@@ -1231,11 +1231,11 @@ func getTaxForAskingUser(tx *gorm.DB, stockId uint32, stockQuantity uint64, stoc
 	var tax uint64
 
 	transactionSummary := &TransactionSummary{UserId: userId, StockId: stockId}
-	tx.First(&transactionSummary)
+	tx.Where("userId = ? AND stockId = ?", userId, stockId).First(&transactionSummary)
 
 	l.Debugf("TransactionSummary object retrieved : %+v", transactionSummary)
 
-	if transactionSummary.StockQuantity != 0 {
+	if transactionSummary.Id != 0 {
 		// This user has already placed orders for this stock before
 
 		currentStocksHeld := float64(transactionSummary.StockQuantity)

--- a/models/User_test.go
+++ b/models/User_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -771,6 +772,75 @@ func Test_PerformBuyFromExchangeTransaction(t *testing.T) {
 			t.Fatalf("User %d's cash not consistent. Got %d; want %d", uid, u.Cash, newCash)
 		}
 	}
+}
+
+// Helper for the deadlock test written below. If you want to test any table OTHER than TransactionSummary,
+// all you need to do is update this helper function. The actual Test_Deadlock function need not be updated.
+func saveTransSum(userID int, t *testing.T) {
+	db := getDB()
+	tx := db.Begin()
+
+	transactionSummary := &TransactionSummary{
+		UserId:        uint32(userID),
+		StockId:       2,
+		StockQuantity: 10,
+		Price:         12.5,
+	}
+
+	if err := tx.Save(transactionSummary).Error; err != nil {
+		t.Errorf("Error updating the transaction summary. Rolling back. Error : +%v", err)
+		tx.Rollback()
+		return
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		t.Errorf("Error committing the transaction. Failing. %+v", err)
+		tx.Rollback()
+		return
+	}
+
+	t.Logf("TransactionSummary table updated successfully - %+v", transactionSummary)
+}
+
+// This is a test for deadlock when multiple goroutines spam insert statements into the TransactionSummary table.
+// However, with a few modifications, it can be made to test any table for deadlock possibilities. Feel free to modify
+// this test if there's any other table you'd like to test insert statements on.
+func Test_Deadlock(t *testing.T) {
+
+	db := getDB()
+	numUsers := 10
+
+	for i := 1; i <= numUsers; i++ {
+		user := &User{Id: uint32(i), Email: fmt.Sprintf("user%v@deadlock.com", i), Cash: 1000000}
+		if err := db.Create(user).Error; err != nil {
+			t.Fatal(err)
+		} else {
+			t.Logf("Created user %v", i)
+		}
+	}
+
+	stock := &Stock{Id: 2, StocksInExchange: 30, CurrentPrice: 100}
+	if err := db.Create(stock).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		db.Exec("DELETE FROM TransactionSummary")
+		db.Exec("DELETE FROM Users")
+		db.Exec("DELETE FROM Stocks")
+	}()
+
+	wg := &sync.WaitGroup{}
+
+	for i := 1; i <= numUsers; i++ {
+		wg.Add(1)
+		go func(userID int) {
+			defer wg.Done()
+			saveTransSum(userID, t)
+		}(i)
+	}
+
+	wg.Wait()
 }
 
 func Test_PerformMortgageTransaction(t *testing.T) {


### PR DESCRIPTION
After a lot of testing, it was found that this deadlock issue occurred **only** for the TransactionSummary table. For example, I tested this issue against the Transactions table and no deadlock occurred. So finally, this was fixed by adding a new AutoIncrement column **id** and making it the primary key.

Why this fixes the issue is still unknown.

This PR closes #250 

