### PR TITLE
Deadlock fix 2

### DIFF
--- a/build_proto.sh
+++ b/build_proto.sh
@@ -8,7 +8,7 @@ protoc --go_out=plugins=grpc,import_prefix=github.com/delta/dalal-street-server/
 protoc --go_out=import_prefix=github.com/delta/dalal-street-server/proto_build/,import_path=actions_pb:. actions/*.proto
 protoc --go_out=import_prefix=github.com/delta/dalal-street-server/proto_build/,import_path=models_pb:. models/*.proto
 protoc --go_out=import_prefix=github.com/delta/dalal-street-server/proto_build/,import_path=datastreams_pb:. datastreams/*.proto
-grep -rl "proto_build" . | grep -v ".sh" | xargs sed -E -i.bak 's|github.com/delta/dalal-street-server/proto_build/(google\|golang\|github)|\1|g'
+grep -rl "proto_build" . | grep -v ".sh" | xargs sed -E -i.bak 's|github.com/delta/dalal-street-server/proto_build/(google\|golang\|github\|context)|\1|g'
 find . -type f -name "*.bak" -exec rm {} \;
 find . -type f -name "*.proto" -exec rm {} \;
 go build

--- a/models/User.go
+++ b/models/User.go
@@ -824,7 +824,7 @@ func PlaceAskOrder(userId uint32, ask *Ask) (uint32, error) {
 		return 0, err
 	}
 
-	l.Infof("Created Ask order. AskId: ", ask.Id)
+	l.Infof("Created Ask order. AskId: %d", ask.Id)
 
 	db := getDB()
 	tx := db.Begin()
@@ -855,13 +855,13 @@ func PlaceAskOrder(userId uint32, ask *Ask) (uint32, error) {
 		return errorHelper("Error saving OrderFeeTransaction. Rolling back. Error: %+v", err)
 	}
 
-	l.Info("Saved OrderFeeTransaction for bid %d", ask.Id)
+	l.Infof("Saved OrderFeeTransaction for bid %d", ask.Id)
 
 	if err := tx.Commit().Error; err != nil {
 		return errorHelper("Error committing the transaction. Failing. %+v", err)
 	}
 
-	l.Info("Commited successfully for bid %d", ask.Id)
+	l.Infof("Commited successfully for bid %d", ask.Id)
 
 	// Update datastreams to add newly placed order in OpenOrders
 	go func(ask *Ask, orderFeeTransaction *Transaction) {
@@ -1000,13 +1000,13 @@ func PlaceBidOrder(userId uint32, bid *Bid) (uint32, error) {
 		return errorHelper("Error saving OrderFeeTransaction. Rolling back. Error: %+v", err)
 	}
 
-	l.Info("Saved OrderFeeTransaction for bid %d", bid.Id)
+	l.Infof("Saved OrderFeeTransaction for bid %d", bid.Id)
 
 	if err := tx.Commit().Error; err != nil {
 		return errorHelper("Error committing the transaction. Failing. %+v", err)
 	}
 
-	l.Info("Commited successfully for bid %d", bid.Id)
+	l.Infof("Commited successfully for bid %d", bid.Id)
 
 	// Update datastreams to add newly placed order in OpenOrders
 	go func(bid *Bid, orderFeeTransaction *Transaction) {
@@ -1544,7 +1544,7 @@ func PerformOrderFillTransaction(ask *Ask, bid *Bid, stockTradePrice uint64, sto
 	}
 
 	if askStatus == AskAlreadyClosed || bidStatus == BidAlreadyClosed {
-		l.Infof("Done. One of the orders already closed. %+s and %+s", askStatus, bidStatus)
+		l.Infof("Done. One of the orders already closed. %+v and %+v", askStatus, bidStatus)
 		return askStatus, bidStatus, nil
 	}
 


### PR DESCRIPTION
Issue #250: Random deadlocks

On lots of debugging, it was found that tx.Save(model) fires 3 queries in the transaction:

1. Update TransactionsTable Set X=foo, Y=bar Where userID=1 and stockID = 1.
2. Select * from TransactionsTable where userID=1 and stockID = 1.
3. Insert into TransactionsTable Values (1, 1, foo, bar).

It tries to update first. Update will return "0 rows affected" in 2 cases:
a. When no row matches the where clause.
b. When the new values are same as old values of the matching row(s).

In this case, Gorm fires Select to check if it was case b. Select returns some rows if they existed earlier.

If Select returns empty set, gorm Inserts a new row.

However, due to the way MySQL works, it seems that Insert and Updates in the same transaction somehow cause a deadlock:

https://bugs.mysql.com/bug.php?id=52020
https://jira.mariadb.org/browse/MDEV-17073

I'm still not sure if this is the cause of the error. Checking MySQL logs, I found that two transactions conflicted on same lock, which shouldn't happen since we're using PRIMARY KEY index in each query, and each query resolves to exactly one row, and MySQL docs say that InnoDB will lock only that row's index record. Since each thread of ours _does_ access different rows, I'm not sure why a common lock even gets involved.

But life is such, and it does get involved, and I can't figure out what the problem is.

So one solution is to not use tx.Save(...) and thus entirely avoid Update-Insert issues. This commit shows that deadlock is avoided by using tx.Where(...).Count(...) first to check if the row exists, and if it does, it calls tx.Update(...), otherwise it calls tx.Create(...)

This shouldn't really be required, and maybe we should file a bug report on Gorm. It's further inefficient to use Update-Save-Insert which uses 3 queries instead of using 2.