### PR TITLE
[proto]: Fix golang context not found error

### DIFF
--- a/build_proto.sh
+++ b/build_proto.sh
@@ -8,7 +8,7 @@ protoc --go_out=plugins=grpc,import_prefix=github.com/delta/dalal-street-server/
 protoc --go_out=import_prefix=github.com/delta/dalal-street-server/proto_build/,import_path=actions_pb:. actions/*.proto
 protoc --go_out=import_prefix=github.com/delta/dalal-street-server/proto_build/,import_path=models_pb:. models/*.proto
 protoc --go_out=import_prefix=github.com/delta/dalal-street-server/proto_build/,import_path=datastreams_pb:. datastreams/*.proto
-grep -rl "proto_build" . | grep -v ".sh" | xargs sed -E -i.bak 's|github.com/delta/dalal-street-server/proto_build/(google\|golang\|github)|\1|g'
+grep -rl "proto_build" . | grep -v ".sh" | xargs sed -E -i.bak 's|github.com/delta/dalal-street-server/proto_build/(google\|golang\|github\|context)|\1|g'
 find . -type f -name "*.bak" -exec rm {} \;
 find . -type f -name "*.proto" -exec rm {} \;
 go build


### PR DESCRIPTION
Thanks @thakkarparth007 for pointing this out.

This fixes the following error being thrown :- 

>DalalMessage.pb.go:9:2: cannot find package "github.com/delta/dalal-street-server/proto_build/context" in any of:
	/usr/local/go/src/github.com/delta/dalal-street-server/proto_build/context (from $GOROOT)
	/go/src/github.com/delta/dalal-street-server/proto_build/context (from $GOPATH)